### PR TITLE
Better MCV pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,50 @@ Angular - Drag and Drop
 
 Drag and drop dataobjects with angular using directives and HTML5
 
--jsFiddle example http://jsfiddle.net/ADukg/2516/
--Live example http://www.devfishy.com/dnd
+jsFiddle example http://jsfiddle.net/ADukg/2516/    <br />
+Live example http://www.devfishy.com/dnd
 
-Original work done by fisshy: https://github.com/fisshy/Angular-drag-drop
+<b>Todo</b> <br/>
+<ul>
+    
+<li>
+ Bind drag to drop, So we only can drop on specific drop if wanted.
+</li>
 
-Everything is intended to be merged on his repo, ne need to fork this one :)
+
+</ul>
+
+<b>drop</b><br/>
+drop      - Context of the drop directive   <br/>
+whenDrop  - Takes a function thats called when drag is dropped  <br/>
+whenEnter - Takes a function thats called when drag enters drop-area    <br/>
+whenLeave - Takes a function thats called when drag leaves drop-area    <br/>
+    
+<b>drag</b><br/>
+drag      - Context of the current drag item. <br/>
+whenStart - Takes a function to be called when drag starts <br />
+whenEnd   - Takes a function to be called when drag ends    <br/>
+
+  	<div ng-controller="MyCtrl" class="wrapper">
+
+          <div class="objects">
+              <div ng-repeat="item in htmlItems"  
+                   drag="item" 
+                   class="span12">
+                  <span>{{item.name}}</span>
+              </div>
+          </div>
+
+          <div drop="html"
+               when-drop="addToLayout(data)"
+               when-enter="previewHtml(data)"
+               when-leave="removePreview(data)"
+               class="html">
+              <div ng-bind-html-unsafe="drop">
+
+              </div>
+          </div>
+
+      </div>
+<b>Exampel of usage</b>
+<a target='_blank' href='http://imageshack.us/photo/my-images/268/angulardnd.png/'><img src='http://img268.imageshack.us/img268/4500/angulardnd.png' border='0'/></a><br></a>

--- a/README.md
+++ b/README.md
@@ -3,50 +3,9 @@ Angular - Drag and Drop
 
 Drag and drop dataobjects with angular using directives and HTML5
 
-jsFiddle example http://jsfiddle.net/ADukg/2516/    <br />
-Live example http://www.devfishy.com/dnd
+-jsFiddle example http://jsfiddle.net/ADukg/2516/
+-Live example http://www.devfishy.com/dnd
 
-<b>Todo</b> <br/>
-<ul>
-    
-<li>
- Bind drag to drop, So we only can drop on specific drop if wanted.
-</li>
+Original work done by fisshy: https://github.com/fisshy/Angular-drag-drop
 
-
-</ul>
-
-<b>drop</b><br/>
-drop      - Context of the drop directive   <br/>
-whenDrop  - Takes a function thats called when drag is dropped  <br/>
-whenEnter - Takes a function thats called when drag enters drop-area    <br/>
-whenLeave - Takes a function thats called when drag leaves drop-area    <br/>
-    
-<b>drag</b><br/>
-drag      - Context of the current drag item. <br/>
-whenStart - Takes a function to be called when drag starts <br />
-whenEnd   - Takes a function to be called when drag ends    <br/>
-
-  	<div ng-controller="MyCtrl" class="wrapper">
-
-          <div class="objects">
-              <div ng-repeat="item in htmlItems"  
-                   drag="item" 
-                   class="span12">
-                  <span>{{item.name}}</span>
-              </div>
-          </div>
-
-          <div drop="html"
-               when-drop="addToLayout(data)"
-               when-enter="previewHtml(data)"
-               when-leave="removePreview(data)"
-               class="html">
-              <div ng-bind-html-unsafe="drop">
-
-              </div>
-          </div>
-
-      </div>
-<b>Exampel of usage</b>
-<a target='_blank' href='http://imageshack.us/photo/my-images/268/angulardnd.png/'><img src='http://img268.imageshack.us/img268/4500/angulardnd.png' border='0'/></a><br></a>
+Everything is intended to be merged on his repo, ne need to fork this one :)

--- a/css/draganddrop.css
+++ b/css/draganddrop.css
@@ -9,7 +9,7 @@
 }
 
 /*
-drop element    
+drop element
 */
 .drop {
     height: 500px;
@@ -18,14 +18,21 @@ drop element
 }
 
 /*
-drag element 
+drag element
 */
 .drag {
     cursor: move;
 }
 
 /*
-class added to all .drop elements while dragging    
+element being dragged
+*/
+.on-drag {
+    opacity: 0.4;
+}
+
+/*
+class added to all .drop elements while dragging
 */
 .dragging {
     padding: 9px;

--- a/javascript/dragandrop.js
+++ b/javascript/dragandrop.js
@@ -22,10 +22,10 @@
                         }
 
                         angular.forEach( drags, function ( value, key ) {
-                            value.className = value.className + ' dragging';
+                            angular.element(value).addClass('dragging');
                         } );
 
-                        this.style.opacity = '0.4';
+                        elem.addClass('on-drag');
 
                         dndApi.setData(scope.item);
 
@@ -39,7 +39,7 @@
 
                     elem[0].addEventListener( 'dragend', function ( e ) {
 
-                        this.style.opacity = '1';
+                        elem.removeClass('on-drag');
 
                         angular.forEach( drags, function ( value, key ) {
                             value.className = value.className.replace( dragging, '' );
@@ -78,6 +78,7 @@
                         top = elem[0].offsetTop,
                         bottom = top + elem[0].offsetHeight;
 
+
                     elem[0].addEventListener( 'drop', function ( e ) {
 
                         if(e.stopPropagation()){
@@ -85,7 +86,7 @@
                         }
 
                         scope.$apply( function () {
-                            scope.whenDrop( { data: dndApi.getData() } );
+                            scope.whenDrop( { data: dndApi.getData(), target: elem } );
                         } );
 
                         if ( drags.length === 0 ) {
@@ -93,9 +94,7 @@
                         }
 
                         angular.forEach( drags, function ( value, key ) {
-
-                            value.className = value.className.replace( dragging, '' );
-
+                            angular.element(value).removeClass('dragging');
                         } );
 
                         dndApi.removeData();
@@ -107,7 +106,7 @@
                         if(elem[0] === e.target)
                         {
                             scope.$apply( function () {
-                                scope.whenEnter( { data: dndApi.getData() } );
+                                scope.whenEnter( { data: dndApi.getData(), target: elem } );
                             } );
                         }
 
@@ -120,10 +119,11 @@
                             (e.y < top  || e.y > bottom) )
                         {
                             scope.$apply( function () {
-                                scope.whenLeave( { data: dndApi.getData() } );
+                                scope.whenLeave( { data: dndApi.getData(), target: elem } );
                             } );
                         }
                     });
+
 
                     elem[0].addEventListener ( 'dragover', function ( e ) {
 
@@ -135,10 +135,12 @@
 
                     } );
 
-                    elem[0].className = elem[0].className + ' drop';
+
+                    elem.addClass('drop');
 
                 }
             };
+
         } ).factory('dndApi', function(){
 
             var dnd = {


### PR DESCRIPTION
This solve a bug when classes are added with jQuery after you manually concatened one using className property. 

It also improve separation between model and view.

As an extra, I added the targeted element to the when-drop function, but I may be missing something. For instance, why do you bind "drop" from the drop directive? Seems like its value ($scope.drop) is never used.

---
- "on-drag" class added or removed instead of hard-coded opacity for
  elements being dragged (opacity moved to css file)
- jQ-lite addClass and removeClass instead of pure js string
  concatenation (makes jQuery addClass break)
- when-drop function returns the target element as a second optional
  parameter
