### PR TITLE
Use non-minified main script

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-dnd",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "homepage": "https://github.com/fisshy/angular-drag-drop",
   "authors": [
     "Joachim Karlsson <Jockkee_@hotmail.com>"
   ],
   "description": "Drag and drop directive using HTML5 api",
-  "main": "angular-dnd.min.js",
+  "main": "angular-dnd.js",
   "keywords": [
     "angular",
     "dragndrop"


### PR DESCRIPTION
Bower [recommends](https://github.com/bower/bower/issues/393) not to use minified files for your main scripts (leave it up to build tools to minify if desired).

```
The primary acting files necessary to use your package. While Bower does not directly use these files, they are listed with the commands bower list map and bower list --sources, so they can be used by build tools. Do not include minified files. Files should not be versioned (Bad: package.1.1.0.js; Good: package.js).
```
